### PR TITLE
Update nightly2.conf to use deps 0.5.1

### DIFF
--- a/config/nightly2.conf
+++ b/config/nightly2.conf
@@ -4,7 +4,7 @@ CONFIGDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 export QGIS_VERSION=3.15
 export VERSION_qt=5.14.2
-export RELEASE_VERSION=0.5.2
+export RELEASE_VERSION=0.5.1
 export RELEASE=nightly2
 
 BASEDIR=/Users/admin/qgis/builds/${RELEASE}


### PR DESCRIPTION
Currently, nightly2.conf is looking for deps 0.5.2, but only 0.5.1 is available.