### PR TITLE
fix  forgot to change install_name for the linked library

### DIFF
--- a/qgis_bundle/recipes/qgis/recipe.sh
+++ b/qgis_bundle/recipes/qgis/recipe.sh
@@ -186,6 +186,7 @@ function fix_binaries_qgis() {
       $LINK_libgsl \
       $LINK_libgslcblas \
       $LINK_libzip \
+      $LINK_libzstd \
       $LINK_libproj \
       $LINK_protobuf_lite \
       $LINK_libpq \


### PR DESCRIPTION
fix QGIS.app/Contents/PlugIns/qgis/libdb2provider.so contains /opt/QGIS/qgis-deps-0.5.5/stage string <-- forgot to change install_name for the linked library?

see https://qgis.org/downloads/macos/nightly/qgis_nightly_master_20201102_122900.log

![image](https://user-images.githubusercontent.com/127259/97964287-ce769d00-1db8-11eb-9ac0-1bbf0e9e145a.png)
