### PR TITLE
Include HANA plugin

### DIFF
--- a/config/dev.conf
+++ b/config/dev.conf
@@ -7,6 +7,7 @@ export RELEASE_VERSION=0.6.0
 export RELEASE=dev
 
 export WITH_ECW="true"
+export WITH_HANA="true"
 export WITH_MRSID="true"
 export WITH_ORACLE="true"
 export WITH_PDAL="true"

--- a/config/nightly.conf
+++ b/config/nightly.conf
@@ -7,6 +7,7 @@ export RELEASE_VERSION=0.6.0
 export RELEASE=nightly
 
 export WITH_ECW="true"
+export WITH_HANA="true"
 export WITH_MRSID="true"
 export WITH_ORACLE="true"
 export WITH_PDAL="true"

--- a/config/pr.conf
+++ b/config/pr.conf
@@ -7,6 +7,7 @@ export RELEASE_VERSION=0.5.5
 export RELEASE=pr
 
 export WITH_ECW="true"
+export WITH_HANA="true"
 export WITH_MRSID="true"
 export WITH_ORACLE="true"
 export WITH_PDAL="false"

--- a/qgis_build/qgis_build.bash
+++ b/qgis_build/qgis_build.bash
@@ -28,6 +28,12 @@ try mkdir -p "$QGIS_INSTALL_DIR"
 # run cmake
 cd $QGIS_BUILD_DIR
 
+if [[ "$WITH_HANA" == "true" ]]; then
+  HANA_CMAKE="-DWITH_HANA=TRUE"
+else
+  HANA_CMAKE="-DWITH_HANA=FALSE"
+fi
+
 if [[ "$WITH_ORACLE" == "true" ]]; then
   ORACLE_SDK="$QGIS_BUILD_SCRIPT_DIR/../../external/oracle/sdk"
   if [ ! -d "$ORACLE_SDK" ]; then
@@ -51,6 +57,7 @@ fi
 # SERVER_SKIP_ECW == ECW in server apps requires a special license
 PATH=$ROOT_OUT_PATH/stage/bin:$PATH \
 cmake -DCMAKE_BUILD_TYPE=Release \
+      $HANA_CMAKE \
       $ORACLE_CMAKE \
       -DQGIS_MAC_DEPS_DIR=$ROOT_OUT_PATH/stage \
       -DCMAKE_PREFIX_PATH=$QT_BASE/clang_64 \

--- a/qgis_bundle/recipes/qgis/recipe.sh
+++ b/qgis_bundle/recipes/qgis/recipe.sh
@@ -112,6 +112,10 @@ function fix_binaries_qgis() {
  install_name_add_rpath @executable_path/../../../../lib $BUNDLE_CONTENTS_DIR/MacOS/lib/qgis/grass/bin/qgis.g.browser7
  install_name_add_rpath @executable_path/../../../../../Resources/grass${VERSION_grass_major}${VERSION_grass_minor}/lib $BUNDLE_CONTENTS_DIR/MacOS/lib/qgis/grass/bin/qgis.g.browser7
 
+ if [[ "$WITH_HANA" == "true" ]]; then
+  HANA_PROVIDER=PlugIns/qgis/libhanaprovider.so
+ fi
+
  if [[ "$WITH_ORACLE" == "true" ]]; then
   ORACLE_PROVIDER=PlugIns/qgis/liboracleprovider.so
  fi
@@ -138,6 +142,7 @@ function fix_binaries_qgis() {
     Frameworks/qgis_analysis.framework/Versions/$QGIS_VERSION/qgis_analysis \
     Frameworks/qgis_gui.framework/Versions/$QGIS_VERSION/qgis_gui \
     Frameworks/qgisgrass${VERSION_grass_major}.framework/Versions/$QGIS_VERSION/qgisgrass${VERSION_grass_major} \
+    $HANA_PROVIDER \
     $ORACLE_PROVIDER \
     $PDALPROVIDER \
     PlugIns/qgis/libgeometrycheckerplugin.so \


### PR DESCRIPTION
The HANA plugin has been recently [merged](https://github.com/qgis/QGIS/pull/34988) into master. This change includes the new plugin in the QGIS-Mac-Packager.