### PR TITLE
fetch_proj-datumgrid.bash: update version numbers

### DIFF
--- a/scripts/fetch_proj-datumgrid.bash
+++ b/scripts/fetch_proj-datumgrid.bash
@@ -9,9 +9,9 @@ PWD=`pwd`
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 WORLD_VER="world-1.0"
-EUROPE_VER="europe-1.2"
-OCEANIA_VER="oceania-1.0"
-NORTH_AMERICA_VER="north-america-1.2"
+EUROPE_VER="europe-1.6"
+OCEANIA_VER="oceania-1.2"
+NORTH_AMERICA_VER="north-america-1.4"
 MAIN_VER="1.8"
 
 WORLD="https://github.com/OSGeo/proj-datumgrid/releases/download/$WORLD_VER/proj-datumgrid-$WORLD_VER.tar.gz"


### PR DESCRIPTION
proj has updated its datum grid downloads more than once since this script was last committed, most recently on 1 March 2020.
This may well be the last change for proj 6. proj 7 has a completely new set of datum grid files in a different repository.