### PR TITLE
Fix codesign --timestamp parameter

### DIFF
--- a/qgis_package/qgis_package.bash
+++ b/qgis_package/qgis_package.bash
@@ -46,7 +46,7 @@ info "Print identities"
 security find-identity -v -p codesigning
 
 info "Signing the $QGIS_APP_NAME"
-codesign -s "$IDENTITY" -v --force –timestamp=none --keychain "$KEYCHAIN_FILE" "$QGIS_APP" --deep
+codesign -s "$IDENTITY" -v --force -–timestamp=none --keychain "$KEYCHAIN_FILE" "$QGIS_APP" --deep
 codesign --deep-verify --verbose "$QGIS_APP"
 
 info "Create dmg image"
@@ -57,7 +57,7 @@ dmgbuild \
   "$PACKAGE"
 
 info "Signing the dmg"
-codesign -s "$IDENTITY" -v --force –timestamp=none --keychain "$KEYCHAIN_FILE" "$PACKAGE"
+codesign -s "$IDENTITY" -v --force -–timestamp=none --keychain "$KEYCHAIN_FILE" "$PACKAGE"
 codesign --deep-verify --verbose "$PACKAGE"
 
 info "Create checksum"


### PR DESCRIPTION
This should fix the failing builds

```
[34;01mSigning the QGIS.app[39;49;00m
–timestamp=none: No such file or directory
FAIL
```
![image](https://user-images.githubusercontent.com/16253859/119216812-2d420080-bad6-11eb-9732-45e0207eb4a8.png)
