### PR TITLE
change deployment target to 10.15

### DIFF
--- a/config/defaults.conf
+++ b/config/defaults.conf
@@ -24,7 +24,7 @@ export QGIS_DOWNLOAD_ROOT_URL="https://qgis.org/downloads/macos"
 # QGIS DEPS
 export ROOT_QT_PATH="/opt/Qt/"
 export QT_BASE="${ROOT_QT_PATH}/${VERSION_qt}"
-export MACOSX_DEPLOYMENT_TARGET=10.13.0
+export MACOSX_DEPLOYMENT_TARGET=10.15.0
 export ROOT_OPT_PATH=/opt/QGIS
 export ROOT_OUT_PATH=${ROOT_OPT_PATH}/qgis-deps-${RELEASE_VERSION}
 # Use QGISDEPS_${module}_DIR to use local repository for build source for {module}


### PR DESCRIPTION
this should fix the compilation issue with untwine: 
error: 'directory_iterator' is unavailable: introduced in macOS 10.15

bug this sounds quite harsh. 
it could be for PR but not LTR?