### PR TITLE
Faster installs by changing DMG compression from BZip2 to LZFSE

### DIFF
--- a/resources/dmgsettings.py
+++ b/resources/dmgsettings.py
@@ -46,7 +46,7 @@ def icon_from_app(app_path):
 # volume_name = 'Test'
 
 # Volume format (see hdiutil create -help)
-format = defines.get('format', 'UDBZ')
+format = defines.get('format', 'ULFO')
 
 # Volume size
 # see https://dmgbuild.readthedocs.io/en/latest/settings.html#size


### PR DESCRIPTION
Installing QGIS 3.32 from the macOS DMG file is **_painfully slow_**: several minutes for the 3GB of files on an idle M1 Max MBP with 32GB of memory, running macOS 13.4. Neither disk load or memory usage is high.

Sampling the diskimages-helper process in Activity Monitor reveals most time is sitting in the BZ2 decompressor. I think the BZip compression is the culprit — I'm not sure if this is Apple Silicon specific or applies to Intel as well. I've noticed the same issue on previous releases/installs too.

<details>
<summary>Process sample of `diskimages-helper`</summary>
Analysis of sampling diskimages-helper (pid 53419) every 1 millisecond
Process:         diskimages-helper [53419]
Path:            /System/Library/PrivateFrameworks/DiskImages.framework/Versions/A/Resources/diskimages-helper
Load Address:    0x100e48000
Identifier:      diskimages-helper
Version:         628.100.8
Code Type:       ARM64E
Platform:        macOS
Parent Process:  ??? [1]

Date/Time:       2023-06-29 2:57:58.181 pm +0200
Launch Time:     2023-06-29 2:52:09.505 pm +0200
OS Version:      macOS 13.4.1 (22F82)
Report Version:  7
Analysis Tool:   /usr/bin/sample

Physical footprint:         14.5M
Physical footprint (peak):  17.0M
Idle exit:                  untracked
----

Call graph:
    2365 Thread_4127041   DispatchQueue_1: com.apple.main-thread  (serial)
    + 2365 start  (in dyld) + 2236  [0x182f07f28]
    +   2365 ???  (in diskimages-helper)  load address 0x100e48000 + 0x7684  [0x100e4f684]
    +     2365 -[NSRunLoop(NSRunLoop) runMode:beforeDate:]  (in Foundation) + 212  [0x1842b5fcc]
    +       2365 CFRunLoopRunSpecific  (in CoreFoundation) + 612  [0x18333c4b8]
    +         2365 __CFRunLoopRun  (in CoreFoundation) + 1208  [0x18333d0c4]
    +           2365 __CFRunLoopServiceMachPort  (in CoreFoundation) + 160  [0x18333e7e4]
    +             2365 mach_msg  (in libsystem_kernel.dylib) + 24  [0x183220290]
    +               2365 mach_msg_overwrite  (in libsystem_kernel.dylib) + 604  [0x183228b78]
    +                 2365 mach_msg2_internal  (in libsystem_kernel.dylib) + 80  [0x183232240]
    +                   2365 mach_msg2_trap  (in libsystem_kernel.dylib) + 8  [0x18321ff14]
    2365 Thread_4129455
      2365 thread_start  (in libsystem_pthread.dylib) + 8  [0x18325ada0]
        2365 _pthread_start  (in libsystem_pthread.dylib) + 148  [0x18325ffa8]
          2365 __NSThread__start__  (in Foundation) + 716  [0x1842af54c]
            2365 ???  (in diskimages-helper)  load address 0x100e48000 + 0xdd88  [0x100e55d88]
              2057 ???  (in diskimages-helper)  load address 0x100e48000 + 0xe568  [0x100e56568]
              ! 2057 ???  (in diskimages-helper)  load address 0x100e48000 + 0xe900  [0x100e56900]
              !   2056 CUDIFDiskImage::readSectors(long long, long long, long long*, void*)  (in DiskImages) + 736  [0x19921e6a0]
              !   : 2056 CUDIFDiskImage::__decompressChunkUsingGlobalBuffer(UDIFRun*, unsigned int)  (in DiskImages) + 84  [0x199222458]
              !   :   2030 CUDIFDiskImage::__decompressChunk(UDIFRun*, void*, void*)  (in DiskImages) + 236  [0x19921e9ec]
              !   :   | 2030 CBZip2Decompressor::decompressData(void const*, int, void*, int)  (in DiskImages) + 48  [0x19925a4ac]
              !   :   |   2024 BZ2_bzBuffToBuffDecompress  (in libbz2.1.0.dylib) + 184  [0x18e862318]
              !   :   |   + 1487 BZ2_bzDecompress  (in libbz2.1.0.dylib) + 3512  [0x18e863200]

</details>

Similar bugs elsewhere:
* [GIMP](https://gitlab.gnome.org/Infrastructure/gimp-macos-build/-/issues/48) switched to ULFO (LZFSE)
* [LibreOffice](https://bugs.documentfoundation.org/show_bug.cgi?id=151341) also switched to ULFO (LZFSE)
* discussion at [create-dmg](https://github.com/create-dmg/create-dmg/issues/128)

[dmgbuild](https://dmgbuild.readthedocs.io/en/latest/settings.html#content-settings) describes the available `format` options. QGIS for Mac is currently documented as supporting macOS High Sierra (10.13) or newer, so I think `ULFO` (LZFSE) is the newest option that can be used at the moment.
