### PR TITLE
Python: Bump to 3.10.13

### DIFF
--- a/config/dev.conf
+++ b/config/dev.conf
@@ -2,7 +2,7 @@
 
 CONFIGDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-export VERSION_major_python=3.9
+export VERSION_major_python=3.10
 export VERSION_qt=5.15.2
 export RELEASE_VERSION=0.9
 export RELEASE_VERSION_PATCH=0

--- a/config/ltr.conf
+++ b/config/ltr.conf
@@ -2,7 +2,7 @@
 
 CONFIGDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-export VERSION_major_python=3.9
+export VERSION_major_python=3.10
 export VERSION_qt=5.15.2
 export RELEASE_VERSION=0.9
 export RELEASE_VERSION_PATCH=0

--- a/config/nightly.conf
+++ b/config/nightly.conf
@@ -2,7 +2,7 @@
 
 CONFIGDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-export VERSION_major_python=3.9
+export VERSION_major_python=3.10
 export VERSION_qt=5.15.2
 export RELEASE_VERSION=0.9
 export RELEASE_VERSION_PATCH=0

--- a/config/pr.conf
+++ b/config/pr.conf
@@ -2,7 +2,7 @@
 
 CONFIGDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-export VERSION_major_python=3.9
+export VERSION_major_python=3.10
 export VERSION_qt=5.15.2
 export RELEASE_VERSION=0.9
 export RELEASE_VERSION_PATCH=0

--- a/qgis_deps/recipes/python/recipe.sh
+++ b/qgis_deps/recipes/python/recipe.sh
@@ -3,7 +3,7 @@
 DESC_python="Interpreted, interactive, object-oriented programming language"
 
 # version of your package (set in config.conf)
-VERSION_minor_python=5
+VERSION_minor_python=13
 VERSION_python=${VERSION_major_python}.${VERSION_minor_python}
 LINK_python=libpython${VERSION_major_python}.dylib
 
@@ -14,7 +14,7 @@ DEPS_python=(openssl xz libffi zlib libzip sqlite expat unixodbc bz2 gettext lib
 URL_python=https://www.python.org/ftp/python/${VERSION_python}/Python-${VERSION_python}.tar.xz
 
 # md5 of the package
-MD5_python=71f7ada6bec9cdbf4538adc326120cfd
+MD5_python=8847dc6458d1431d0ae0f55942deeb89
 
 # default build path
 BUILD_python=$BUILD_PATH/python/$(get_directory $URL_python)


### PR DESCRIPTION
I can't test by myself, so it's only a “dummy” bump of VERSION_*_python variables (and md5). 
Let's see if it packages with the CI?

Feel free to close this pr and replace it with a more robust one, as you know these scripts better than I do. 

Required by https://github.com/qgis/QGIS/pull/56499 
Fixes https://github.com/qgis/QGIS/issues/54491